### PR TITLE
fix: Soluciona Error de CSRF Token #67

### DIFF
--- a/decide/census/templates/import_census.html
+++ b/decide/census/templates/import_census.html
@@ -151,40 +151,44 @@
                 const fileInput = document.getElementById('fileInput').files[0];
                 formData.append('file', fileInput);
 
-                fetch('/census/import/', {
-                        method: 'POST',
-                        body: formData,
-                    })
-                    .then(response => {
-                        if (response.ok) {
-                            return response.json();
-                        }
-                        throw new Error('Network response was not ok.');
-                    })
-                    .then(data => {
-                        document.getElementById('importStatus').innerHTML = data.message;
-                        document.getElementById('errorStatus').innerHTML = ''; // Clear any previous error message
-                        showMessageBox();
-                    })
-                    .catch(error => {
-                        console.error('There has been a problem with your fetch operation:', error);
+                // Retrieve CSRF token from the page and append it to the FormData
+                const csrfToken = document.getElementsByName('csrfmiddlewaretoken')[0].value;
+                formData.append('csrfmiddlewaretoken', csrfToken);
 
-                        if (error.response) {
-                            console.error('Response status:', error.response.status);
-                            console.error('Response message:', error.response.statusText);
-                            document.getElementById('importStatus').innerHTML = '';
-                            document.getElementById('errorStatus').innerHTML = 'Error importing census: ' + error.response.statusText;
-                            showMessageBox();
-                        } else {
-                            console.error('Error without a response:', error);
-                            document.getElementById('importStatus').innerHTML = '';
-                            document.getElementById('errorStatus').innerHTML = 'Error importing census. Please check your file for invalid or duplicated data and try again.';
-                            showMessageBox();
-                        }
-                    });
+                fetch('/census/import/', {
+                    method: 'POST',
+                    body: formData,
+                })
+                .then(response => {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                    throw new Error('Network response was not ok.');
+                })
+                .then(data => {
+                    document.getElementById('importStatus').innerHTML = data.message;
+                    document.getElementById('errorStatus').innerHTML = ''; // Clear any previous error message
+                    showMessageBox();
+                })
+                .catch(error => {
+                    console.error('There has been a problem with your fetch operation:', error);
+
+                    if (error.response) {
+                        console.error('Response status:', error.response.status);
+                        console.error('Response message:', error.response.statusText);
+                        document.getElementById('importStatus').innerHTML = '';
+                        document.getElementById('errorStatus').innerHTML = 'Error importing census: ' + error.response.statusText;
+                        showMessageBox();
+                    } else {
+                        console.error('Error without a response:', error);
+                        document.getElementById('importStatus').innerHTML = '';
+                        document.getElementById('errorStatus').innerHTML = 'Error importing census. Please check your file for invalid or duplicated data and try again.';
+                        showMessageBox();
+                    }
+                });
             });
 
-            function showMessageBox() {
+        function showMessageBox() {
                 const messageBox = document.getElementById('messageBox');
                 messageBox.style.display = 'block';
             }

--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -341,7 +341,7 @@ class CensusImportViewTest(TestCase):
         workbook = Workbook()
         sheet = workbook.active
         sheet.append(['voting_id', 'voter_id', 'creation_date', 'additional_info'])
-        sheet.append([1, 1, '2023-11-28 11:47:12.015914+00:00'])
+        sheet.append([1, '2023-11-28 11:47:12.015914+00:00'])
         excel_buffer = BytesIO()
         workbook.save(excel_buffer)
         excel_buffer.seek(0)


### PR DESCRIPTION
Parece que el token CSRF, algo necesario para que solo los administradores puedan importar censos, ha dejado de funcionar a pesar de que en versiones anteriores funcionaba sin problemas, lo que impedía que se pudiesen importar censos. Probablemente alguien haya tocado algo sin querer que haya afectado su funcionamiento.

He solucionado el problema y la importación de censos vuelve a funcionar.