### PR TITLE
feat: Implementa Importacion de Censos en XML

### DIFF
--- a/decide/census/templates/import_census.html
+++ b/decide/census/templates/import_census.html
@@ -125,8 +125,8 @@
         <div class="line"></div>
         <form id="importForm" enctype="multipart/form-data" method="post">
             {% csrf_token %}
-            <label for="fileInput">Attach a CSV, JSON, or XLSX file:</label>
-            <input type="file" id="fileInput" name="file" accept=".csv, application/json, .xlsx" required>
+            <label for="fileInput">Attach a CSV, JSON, XLSX or XML file:</label>
+            <input type="file" id="fileInput" name="file" accept=".csv, application/json, .xlsx, .xml" required>
             <div class="line"></div>
             <button type="submit">Import Census</button>
         </form>

--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -251,7 +251,8 @@ class CensusImportViewTest(TestCase):
         )
 
     def tearDown(self):
-        Census.objects.all().delete()
+        self.client.logout()
+        super().tearDown()
 
     def login_as_admin(self):
         self.client.force_login(self.admin_user)

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -146,13 +146,17 @@ class CensusImportView(View):
             tree = ET.ElementTree(ET.fromstring(xml_content))
             root = tree.getroot()
             censuses = root.findall('.//Census')
-            reader = [(census.find('VotingID').text,
-                       census.find('VoterID').text,
-                       census.find('CreationDate').text,
-                       census.find('AdditionalInfo').text) for census in censuses]
+            reader = [
+                (
+                    census.find('VotingID').text if census.find('VotingID') is not None else None,
+                    census.find('VoterID').text if census.find('VoterID') is not None else None,
+                    census.find('CreationDate').text if census.find('CreationDate') is not None else None,
+                    census.find('AdditionalInfo').text if census.find('AdditionalInfo') is not None else None
+                )
+                for census in censuses
+            ]
         else:
             return None, JsonResponse({'error': 'Unsupported file format'}, status=400)
-
         return reader, None
 
     def create_census_object(self, row):


### PR DESCRIPTION
Se ha añadido un cuarto método de importación de censos. Ficheros XML.

También se han implementado 3 nuevas pruebas.